### PR TITLE
[imgui_sandbox] Fix bug in call to RegisterClassExW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@
 /build/vs/chaiscript/Release
 /build/vs/imgui_sandbox/Debug
 /build/vs/imgui_sandbox/Release
+imgui.ini

--- a/examples/imgui_sandbox/main.cpp
+++ b/examples/imgui_sandbox/main.cpp
@@ -192,7 +192,7 @@ int WINAPI wWinMain(HINSTANCE /*instance*/,
   wc.lpfnWndProc = WndProc;
   wc.hInstance = GetModuleHandleW(nullptr);
   wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
-  wc.lpszClassName = L"ImGui Example";
+  wc.lpszClassName = L"ImGui Sandbox";
   ::RegisterClassExW(&wc);
   HWND hwnd = ::CreateWindowExW(0,
                                 L"ImGui Sandbox",


### PR DESCRIPTION
I was poking around your various examples and noticed the call to CreateWindowExW was failing because it was using a different class name than what was registered.